### PR TITLE
fetch popular products using view count

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "sass-rails"
 gem "sprockets", "<4"
 gem "httparty", "~> 0.21.0"
 gem 'multi_xml', '0.6.0'
+gem 'impressionist'
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    impressionist (2.0.0)
+      nokogiri (~> 1)
     inherited_resources (1.13.1)
       actionpack (>= 5.2, < 7.1)
       has_scope (~> 0.6)
@@ -383,6 +385,7 @@ DEPENDENCIES
   faker (~> 3.2)
   graphql
   httparty (~> 0.21.0)
+  impressionist
   multi_xml (= 0.6.0)
   pg (~> 1.1)
   pry-byebug

--- a/app/graphql/queries/viewed_products.rb
+++ b/app/graphql/queries/viewed_products.rb
@@ -3,7 +3,9 @@ module Queries
     type Types::ProductType.connection_type, null: false
 
     def resolve
-      current_user.product_views.includes(:product).map(&:product)
+      product_with_views = current_user.product_views.includes(:product).map(&:product)
+
+      popular_products = product_with_views.sort_by { |product| product.views_count }.reverse
     end
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -19,6 +19,7 @@
 class Product < ApplicationRecord
   has_many_attached :images
   acts_as_taggable_on :categories
+  is_impressionable counter_cache: true, column_name: :views_count, unique: :session_hash
 
   has_many :reviews, dependent: :destroy
   has_many :views, class_name: "ProductView", dependent: :destroy

--- a/config/initializers/impression.rb
+++ b/config/initializers/impression.rb
@@ -1,0 +1,8 @@
+# Use this hook to configure impressionist parameters
+#Impressionist.setup do |config|
+  # Define ORM. Could be :active_record (default), :mongo_mapper or :mongoid
+  # config.orm = :active_record
+#end
+
+
+

--- a/db/migrate/20231130004734_create_impressions_table.rb
+++ b/db/migrate/20231130004734_create_impressions_table.rb
@@ -1,0 +1,32 @@
+class CreateImpressionsTable < ActiveRecord::Migration[7.0]
+  def self.up
+    create_table :impressions, :force => true do |t|
+      t.string :impressionable_type
+      t.integer :impressionable_id
+      t.integer :user_id
+      t.string :controller_name
+      t.string :action_name
+      t.string :view_name
+      t.string :request_hash
+      t.string :ip_address
+      t.string :session_hash
+      t.text :message
+      t.text :referrer
+      t.text :params
+      t.timestamps
+    end
+    add_index :impressions, [:impressionable_type, :message, :impressionable_id], :name => "impressionable_type_message_index", :unique => false, :length => {:message => 255 }
+    add_index :impressions, [:impressionable_type, :impressionable_id, :request_hash], :name => "poly_request_index", :unique => false
+    add_index :impressions, [:impressionable_type, :impressionable_id, :ip_address], :name => "poly_ip_index", :unique => false
+    add_index :impressions, [:impressionable_type, :impressionable_id, :session_hash], :name => "poly_session_index", :unique => false
+    add_index :impressions, [:controller_name,:action_name,:request_hash], :name => "controlleraction_request_index", :unique => false
+    add_index :impressions, [:controller_name,:action_name,:ip_address], :name => "controlleraction_ip_index", :unique => false
+    add_index :impressions, [:controller_name,:action_name,:session_hash], :name => "controlleraction_session_index", :unique => false
+    add_index :impressions, [:impressionable_type, :impressionable_id, :params], :name => "poly_params_request_index", :unique => false, :length => {:params => 255 }
+    add_index :impressions, :user_id
+  end
+
+  def self.down
+    drop_table :impressions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_27_215757) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_30_004734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,6 +66,32 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_27_215757) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
+
+  create_table "impressions", force: :cascade do |t|
+    t.string "impressionable_type"
+    t.integer "impressionable_id"
+    t.integer "user_id"
+    t.string "controller_name"
+    t.string "action_name"
+    t.string "view_name"
+    t.string "request_hash"
+    t.string "ip_address"
+    t.string "session_hash"
+    t.text "message"
+    t.text "referrer"
+    t.text "params"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["controller_name", "action_name", "ip_address"], name: "controlleraction_ip_index"
+    t.index ["controller_name", "action_name", "request_hash"], name: "controlleraction_request_index"
+    t.index ["controller_name", "action_name", "session_hash"], name: "controlleraction_session_index"
+    t.index ["impressionable_type", "impressionable_id", "ip_address"], name: "poly_ip_index"
+    t.index ["impressionable_type", "impressionable_id", "params"], name: "poly_params_request_index"
+    t.index ["impressionable_type", "impressionable_id", "request_hash"], name: "poly_request_index"
+    t.index ["impressionable_type", "impressionable_id", "session_hash"], name: "poly_session_index"
+    t.index ["impressionable_type", "message", "impressionable_id"], name: "impressionable_type_message_index"
+    t.index ["user_id"], name: "index_impressions_on_user_id"
   end
 
   create_table "product_views", force: :cascade do |t|


### PR DESCRIPTION
- I added a gem called **"impressionist"** to the gemfile.
- The gem tracks the impressions on a product in this case **views**
- I included "is_impressionable" on the Product model and creates a column in the model that counts the views and prevents the current user from increasing the number of times a product is viewed. 
- This allows the current user to have a single view count per session.
- In the the viewed product resolve I declare a variable that handles the count based on views.